### PR TITLE
add standard log package shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ the needs of most programs. The `Log` and `Debug` functions support fmt-style
 formatting but augment the syntax with features that make it simpler to generate
 meaningful events. Refer to the package's documentation to learn more about it.
 
+### Compatibility with the standard library
+
+The standard `log` package doesn't give much flexibility when it comes to its
+logger type. It is a concrete type and there is no `Logger` interface which
+would make it easy to plugin different implementations in packages that need to
+log events. Unfortunately many of these packages have hard dependencies on the
+standard logger, making it hard to capture their events and produce them in
+different formats.  
+However, the `events/log` package is a shim between the standard `log` package,
+and a stream of events. It exposes an API compatible with the standard library,
+and automatically configures the `log` package to reroute the messages it emits
+as events to the default logger.
+
 ## Handlers
 
 Event handlers are the abstraction layer that allows to connect event sources to

--- a/log/doc.go
+++ b/log/doc.go
@@ -1,0 +1,11 @@
+// Package log provides the implementation of a shim between the standard log
+// package and event handlers.
+//
+// The package exposes an API that mimics the standard library, in most cases it
+// can be used as a drop in replacement by simply rewriting the import from
+// "log" to "github.com/segmentio/events/log".
+//
+// Importing this package has the side effect of configuring the default output
+// of the log package to route events to the default logger of the events
+// package.
+package log

--- a/log/init.go
+++ b/log/init.go
@@ -1,0 +1,7 @@
+package log
+
+import "log"
+
+func init() {
+	log.SetOutput(defaultWriter)
+}

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,220 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/segmentio/events"
+	"github.com/segmentio/events/ecslogs"
+	"github.com/segmentio/events/text"
+)
+
+// New creates a new Logger. The out variable sets the destination to which log
+// data will be written. The prefix appears at the beginning of each generated
+// log line. The flag argument defines the logging properties.
+func New(out io.Writer, prefix string, flags int) *log.Logger {
+	return NewLogger(prefix, flags, NewHandler(out))
+}
+
+// NewLogger creates a new logger. The prefix and flags arguments configure the
+// behavior of the logger, while handler sets the destination to which log
+// events are sent.
+func NewLogger(prefix string, flags int, handler events.Handler) *log.Logger {
+	return log.New(NewWriter(prefix, flags, handler), prefix, flags)
+}
+
+// NewHandler creates an event handler with best suits w.
+func NewHandler(w io.Writer) events.Handler {
+	var term bool
+
+	if w == nil {
+		return defaultHandler
+	}
+
+	if f, ok := w.(interface {
+		Fd() uintptr
+	}); ok {
+		term = terminal.IsTerminal(int(f.Fd()))
+	}
+
+	if term {
+		return text.NewHandler("", w)
+	}
+	return ecslogs.NewHandler(w)
+}
+
+var (
+	// The default handler used by the global output.
+	defaultHandler = events.HandlerFunc(func(e *events.Event) {
+		events.DefaultLogger.Handler.HandleEvent(e)
+	})
+
+	// Cache of the output set for the default logger, we need this because the
+	// standard log package doesn't expose any API to retrieve it.
+	defaultWriter *Writer = NewWriter(log.Prefix(), log.Flags(), defaultHandler)
+)
+
+// =============================================================================
+// Copyright (c) 2009 The Go Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//
+// * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+const (
+	// Bits or'ed together to control what's printed.
+	// There is no control over the order they appear (the order listed
+	// here) or the format they present (as described in the comments).
+	// The prefix is followed by a colon only when Llongfile or Lshortfile
+	// is specified.
+	// For example, flags Ldate | Ltime (or LstdFlags) produce,
+	//2009/01/23 01:23:23 message
+	// while flags Ldate | Ltime | Lmicroseconds | Llongfile produce,
+	//2009/01/23 01:23:23.123123 /a/b/c/d.go:23: message
+	Ldate         = log.Ldate         // the date in the local time zone: 2009/01/23
+	Ltime         = log.Ltime         // the time in the local time zone: 01:23:23
+	Lmicroseconds = log.Lmicroseconds // microsecond resolution: 01:23:23.123123.  assumes Ltime.
+	Llongfile     = log.Llongfile     // full file name and line number: /a/b/c/d.go:23
+	Lshortfile    = log.Lshortfile    // final file name element and line number: d.go:23. overrides Llongfile
+	LUTC          = log.LUTC          // if Ldate or Ltime is set, use UTC rather than the local time zone
+	LstdFlags     = log.LstdFlags     // initial values for the standard logger
+)
+
+// SetOutput sets the output destination for the standard logger.
+func SetOutput(w io.Writer) {
+	handler := NewHandler(w)
+	defaultWriter.mutex.Lock()
+	defaultWriter.handler = handler
+	defaultWriter.mutex.Unlock()
+}
+
+// Flags returns the output flags for the standard logger.
+func Flags() int {
+	return log.Flags()
+}
+
+// SetFlags sets the output flags for the standard logger.
+func SetFlags(flags int) {
+	defaultWriter.mutex.Lock()
+	log.SetFlags(flags)
+	defaultWriter.flags = flags
+	defaultWriter.mutex.Unlock()
+}
+
+// Prefix returns the output prefix for the standard logger.
+func Prefix() string {
+	return log.Prefix()
+}
+
+// SetPrefix sets the output prefix for the standard logger.
+func SetPrefix(prefix string) {
+	defaultWriter.mutex.Lock()
+	log.SetPrefix(prefix)
+
+	// Special case if the default writer is backed by a text handler so we can
+	// make it output the right prefix.
+	if h, ok := defaultWriter.handler.(*text.Handler); ok {
+		h.Prefix = prefix
+	}
+
+	defaultWriter.prefix = prefix
+	defaultWriter.mutex.Unlock()
+}
+
+// Print calls Output to print to the standard logger.
+// Arguments are handled in the manner of fmt.Print.
+func Print(v ...interface{}) {
+	log.Output(2, fmt.Sprint(v...))
+}
+
+// Printf calls Output to print to the standard logger.
+// Arguments are handled in the manner of fmt.Printf.
+func Printf(format string, v ...interface{}) {
+	log.Output(2, fmt.Sprintf(format, v...))
+}
+
+// Println calls Output to print to the standard logger.
+// Arguments are handled in the manner of fmt.Println.
+func Println(v ...interface{}) {
+	log.Output(2, fmt.Sprintln(v...))
+}
+
+// Fatal is equivalent to Print() followed by a call to os.Exit(1).
+func Fatal(v ...interface{}) {
+	log.Output(2, fmt.Sprint(v...))
+	os.Exit(1)
+}
+
+// Fatalf is equivalent to Printf() followed by a call to os.Exit(1).
+func Fatalf(format string, v ...interface{}) {
+	log.Output(2, fmt.Sprintf(format, v...))
+	os.Exit(1)
+}
+
+// Fatalln is equivalent to Println() followed by a call to os.Exit(1).
+func Fatalln(v ...interface{}) {
+	log.Output(2, fmt.Sprintln(v...))
+	os.Exit(1)
+}
+
+// Panic is equivalent to Print() followed by a call to panic().
+func Panic(v ...interface{}) {
+	s := fmt.Sprint(v...)
+	log.Output(2, s)
+	panic(s)
+}
+
+// Panicf is equivalent to Printf() followed by a call to panic().
+func Panicf(format string, v ...interface{}) {
+	s := fmt.Sprintf(format, v...)
+	log.Output(2, s)
+	panic(s)
+}
+
+// Panicln is equivalent to Println() followed by a call to panic().
+func Panicln(v ...interface{}) {
+	s := fmt.Sprintln(v...)
+	log.Output(2, s)
+	panic(s)
+}
+
+// Output writes the output for a logging event. The string s contains
+// the text to print after the prefix specified by the flags of the
+// Logger. A newline is appended if the last character of s is not
+// already a newline. Calldepth is the count of the number of
+// frames to skip when computing the file name and line number
+// if Llongfile or Lshortfile is set; a value of 1 will print the details
+// for the caller of Output.
+func Output(calldepth int, s string) error {
+	return log.Output(calldepth+1, s) // +1 for this frame.
+}
+
+// =============================================================================

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,184 @@
+package log
+
+import (
+	"bytes"
+	"io/ioutil"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/segmentio/events"
+)
+
+func TestNewLogger(t *testing.T) {
+	tests := []struct {
+		prefix string
+		flags  int
+		format string
+		args   []interface{}
+		event  events.Event
+	}{
+		{ // empty
+			prefix: "",
+			flags:  0,
+			format: "",
+			args:   nil,
+			event:  events.Event{},
+		},
+		{ // simple
+			prefix: "==> ",
+			flags:  0,
+			format: "Hello World!",
+			args:   nil,
+			event: events.Event{
+				Message: "Hello World!",
+			},
+		},
+		{ // formatted
+			prefix: "==> ",
+			flags:  0,
+			format: "Hello %s!",
+			args:   []interface{}{"Luke"},
+			event: events.Event{
+				Message: "Hello Luke!",
+			},
+		},
+		{ // stdFlags
+			prefix: "==> ",
+			flags:  LstdFlags,
+			format: "Hello World!",
+			args:   nil,
+			event: events.Event{
+				Message: "Hello World!",
+			},
+		},
+		{ // date + microseconds + UTC
+			prefix: "==> ",
+			flags:  Ldate | Lmicroseconds | LUTC,
+			format: "Hello World!",
+			args:   nil,
+			event: events.Event{
+				Message: "Hello World!",
+			},
+		},
+		{ // date only
+			prefix: "==> ",
+			flags:  Ldate,
+			format: "Hello World!",
+			args:   nil,
+			event: events.Event{
+				Message: "Hello World!",
+			},
+		},
+		{ // time only
+			prefix: "==> ",
+			flags:  Ltime,
+			format: "Hello World!",
+			args:   nil,
+			event: events.Event{
+				Message: "Hello World!",
+			},
+		},
+		{ // microseconds only
+			prefix: "==> ",
+			flags:  Lmicroseconds,
+			format: "Hello World!",
+			args:   nil,
+			event: events.Event{
+				Message: "Hello World!",
+			},
+		},
+		{ // shortfile
+			prefix: "==> ",
+			flags:  Lshortfile,
+			format: "Hello World!",
+			args:   nil,
+			event: events.Event{
+				Message: "Hello World!",
+			},
+		},
+		{ // longfile
+			prefix: "==> ",
+			flags:  Llongfile,
+			format: "Hello World!",
+			args:   nil,
+			event: events.Event{
+				Message: "Hello World!",
+			},
+		},
+		{ // all
+			prefix: "==> ",
+			flags:  Ldate | Lmicroseconds | LUTC | Llongfile,
+			format: "Hello %s!",
+			args:   []interface{}{"Luke"},
+			event: events.Event{
+				Message: "Hello Luke!",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			result := []*events.Event{}
+			logger := NewLogger(test.prefix, test.flags, events.HandlerFunc(func(e *events.Event) {
+				result = append(result, e.Clone())
+			}))
+			logger.Printf(test.format, test.args...)
+
+			if len(result) != 1 {
+				t.Error("bad events count:", result)
+				return
+			}
+
+			t.Logf("%#v", *result[0])
+
+			// unpredictable values
+			result[0].Source = ""
+			result[0].Time = time.Time{}
+
+			if !reflect.DeepEqual(*result[0], test.event) {
+				t.Error("bad event")
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	b := &bytes.Buffer{}
+	l := New(b, "==> ", Ldate|Lmicroseconds|LUTC|Llongfile)
+	l.Printf("Hello %s!", "Luke")
+
+	// We can't control the time or source line this test is gonna be using so
+	// we just check that the result isn't empty and output it so humans can
+	// take a look at it.
+	if b.Len() == 0 {
+		t.Error("no bytes were produced")
+	}
+
+	t.Log(b.String())
+}
+
+func TestPrintf(t *testing.T) {
+	b := &bytes.Buffer{}
+	SetOutput(b)
+	SetPrefix("==> ")
+	SetFlags(Ldate | Lmicroseconds | LUTC | Llongfile)
+	Printf("Hello %s!", "Luke")
+
+	// We can't control the time or source line this test is gonna be using so
+	// we just check that the result isn't empty and output it so humans can
+	// take a look at it.
+	if b.Len() == 0 {
+		t.Error("no bytes were produced")
+	}
+
+	t.Log(b.String())
+}
+
+func BenchmarkLogger(b *testing.B) {
+	l := New(ioutil.Discard, "==> ", Ldate|Lmicroseconds|LUTC|Llongfile)
+
+	for i := 0; i != b.N; i++ {
+		l.Printf("Hello World!")
+	}
+}

--- a/log/writer.go
+++ b/log/writer.go
@@ -1,0 +1,152 @@
+package log
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/segmentio/events"
+)
+
+// Writer is an implementation of an io.Writer which is designed to be set as
+// output on a logger from the standard log package.
+//
+// The Writer parses the lines it receives when its Write method is called and
+// constructs events that are then passed to its handler.
+//
+// It is safe to use an Writer from multiple goroutines. However a single writer
+// should be associated with a single logger, the behavior is undefined.
+type Writer struct {
+	handler events.Handler // the handler to send the events to
+	prefix  string         // the prefix set on the logger that uses this output
+	flags   int            // the flags set on the logger that uses this output
+	mutex   sync.Mutex     // the mutex used to control access to the writer
+}
+
+// NewWriter constructs a new Writer value which is intended to be set on a
+// logger configured with prefix and flags, the output forwards events to the
+// given handler.
+func NewWriter(prefix string, flags int, handler events.Handler) *Writer {
+	return &Writer{
+		handler: handler,
+		prefix:  prefix,
+		flags:   flags,
+	}
+}
+
+// Write satisfies the io.Writer interface.
+func (w *Writer) Write(b []byte) (int, error) {
+	if len(b) == 0 {
+		return 0, nil
+	}
+
+	var e = eventPool.Get().(*events.Event)
+	var s = *(*string)(unsafe.Pointer(&reflect.StringHeader{
+		Data: uintptr(unsafe.Pointer(&b[0])),
+		Len:  len(b),
+	}))
+	var t time.Time
+	var src string
+
+	w.mutex.Lock()
+	flags, prefix := w.flags, w.prefix
+
+	if strings.HasPrefix(s, prefix) {
+		s = s[len(prefix):]
+	}
+
+	if format := timeFormat(flags); len(format) != 0 {
+		var tz *time.Location
+		var ts string
+
+		if n := len(format); len(s) >= n {
+			ts, s = s[:n], s[n:]
+		} else {
+			ts, s = s, ""
+		}
+
+		if (flags & LUTC) != 0 {
+			tz = time.UTC
+		} else {
+			tz = time.Local
+		}
+
+		t, _ = time.ParseInLocation(format, ts, tz)
+	}
+
+	if (flags & (Llongfile | Lshortfile)) != 0 {
+		var base string
+		var file string
+		var line string
+
+		s = skip(s, ' ')
+		base = s
+		file, s = parse(s, ':') // parse the file name or path
+		line, s = parse(s, ':') // parse the line number
+
+		src = base[:len(file)+len(line)+1]
+	}
+
+	s = skip(s, ' ')
+
+	if n := strings.IndexByte(s, '\n'); n >= 0 {
+		s = s[:n]
+	}
+
+	if t == (time.Time{}) {
+		t = time.Now()
+	}
+
+	e.Message = s
+	e.Source = src
+	e.Time = t
+
+	w.handler.HandleEvent(e)
+	w.mutex.Unlock()
+
+	e.Message = ""
+	e.Source = ""
+	e.Time = time.Time{}
+	eventPool.Put(e)
+
+	return len(b), nil
+}
+
+func timeFormat(flags int) string {
+	switch flags & (Ldate | Ltime | Lmicroseconds) {
+	case Ldate | Ltime | Lmicroseconds, Ldate | Lmicroseconds:
+		return "2006/01/02 15:04:05.999999"
+	case Ldate | Ltime:
+		return "2006/01/02 15:04:05"
+	case Ldate:
+		return "2006/01/02"
+	case Ltime | Lmicroseconds, Lmicroseconds:
+		return "15:04:05.999999"
+	case Ltime:
+		return "15:04:05"
+	default:
+		return ""
+	}
+}
+
+func skip(s string, b byte) string {
+	if len(s) != 0 && s[0] == b {
+		s = s[1:]
+	}
+	return s
+}
+
+func parse(s string, b byte) (left string, right string) {
+	if index := strings.IndexByte(s, b); index >= 0 {
+		left, right = s[:index], s[index+1:]
+	} else {
+		left = s
+	}
+	return
+}
+
+var eventPool = sync.Pool{
+	New: func() interface{} { return &events.Event{} },
+}


### PR DESCRIPTION
@f2prateek 
@yields 

This is the Holy Grail of logging libraries, by simply importing the package, all messages logged by all packages using the standard `log` library will be re-routed to `events.DefaultLogger`. This means that there can be no more unformatted messages in the program's output, everything will be produced in the same format no matter what logging package is being used.

It also makes it possible to create a `*log.Logger` that, instead of writing to an `io.Writer`, will produce events to an `events.Handler`. This is really useful when using packages that have public APIs that depend on `log`, for example:
```go
import (
    "net/http"

    "github.com/segmentio/events"
    "github.com/segmentio/events/log"

    "labix.org/v2/mgo"
)

...

server := http.Server{
    ...
    // ErrorLog is an *log.Logger, but events/log allows us to create a logger that
    // actually produces events.
    ErrorLog: log.NewLogger(
        "[http] ",
        log.LstdFlags,
        events.HandlerFunc(func(e *events.Event) { ... }),
    ),
}

...
// Mimic the standard log package, but using a nil writer will actually route the
// messages to events.DefaultLogger.
mgo.SetLogger(log.New(nil, "[mongo] ", log.stdFlags))
```

Please take a look and let me know if something should be changed.