### PR TITLE
add events.Signal

### DIFF
--- a/signal.go
+++ b/signal.go
@@ -1,0 +1,42 @@
+package events
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"time"
+)
+
+// Signal triggers events on handler for every signal that arrives on sigchan.
+// The function returns a channel on which signals are forwarded, the program
+// should use this channel instead of sigchan to receive signals.
+func Signal(sigchan <-chan os.Signal, handler Handler) <-chan os.Signal {
+	output := make(chan os.Signal)
+
+	// We capture the stack frame here instead of in the goroutine because it
+	// gives a more meaningful value (the caller of Signal, which usually is
+	// the application itself).
+	var pc [1]uintptr
+	runtime.Callers(2, pc[:])
+	file, line := SourceForPC(pc[0])
+
+	go func() {
+		for sig := range sigchan {
+			handler.HandleEvent(&Event{
+				Message: sig.String(),
+				Source:  fmt.Sprintf("%s:%d", file, line),
+				Time:    time.Now(),
+				Args:    Args{{"signal", sig}},
+			})
+			// Limits to 1s the attempt to publish to the output channel, this
+			// is a safeguard for programs that don't consume from the output
+			// channel (event though they should).
+			select {
+			case output <- sig:
+			case <-time.After(time.Second):
+			}
+		}
+	}()
+
+	return output
+}

--- a/signal_test.go
+++ b/signal_test.go
@@ -1,0 +1,50 @@
+package events
+
+import (
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSignal(t *testing.T) {
+	evlist := []*Event{}
+	sigchan := make(chan os.Signal, 1)
+	handler := HandlerFunc(func(e *Event) { evlist = append(evlist, e.Clone()) })
+
+	sigchan <- os.Interrupt
+	output := Signal(sigchan, handler)
+
+	select {
+	case sig := <-output:
+		if sig != os.Interrupt {
+			t.Error("bad signal received:", sig)
+		}
+	case <-time.After(time.Second):
+		t.Error("no signal received after 1s")
+	}
+
+	if len(evlist) != 1 {
+		t.Error("bad result count:", len(evlist))
+		return
+	}
+
+	if evlist[0].Source == "" {
+		t.Error("missing source in generated event")
+	}
+
+	if evlist[0].Time == (time.Time{}) {
+		t.Error("missing time in generated event")
+	}
+
+	// Unpredictable values.
+	evlist[0].Source = ""
+	evlist[0].Time = time.Time{}
+
+	if !reflect.DeepEqual(*evlist[0], Event{
+		Message: "interrupt",
+		Args:    Args{{"signal", os.Interrupt}},
+	}) {
+		t.Errorf("bad event: %#v", *evlist[0])
+	}
+}


### PR DESCRIPTION
@f2prateek 
@yields 

Added a wrapper for a channel of signals that send events to a handler for each signal received. Here's an example of how it's intended to be used:
```go
sigchan := make(chan os.Signal, 1)
signal.Notify(sigchan, os.Interrupt)

// Sends all signals to the default logger's handler (log the event).
for sig := range events.Signal(sigchan, events.DefaultLogger.Handler) {
    ...
}
```
Please take a look and let me know if you'd like to see anything changed.