### PR TITLE
add netevents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# Emacs
+*~

--- a/netevents/conn.go
+++ b/netevents/conn.go
@@ -1,0 +1,48 @@
+package netevents
+
+import (
+	"net"
+	"sync"
+
+	"github.com/segmentio/events"
+)
+
+type connLogger struct {
+	net.Conn
+	*events.Logger
+	typ  string
+	once sync.Once
+}
+
+func (conn *connLogger) Close() error {
+	conn.close(1)
+	return conn.Conn.Close()
+}
+
+func (conn *connLogger) open(depth int) {
+	conn.log(depth+1, "opening")
+}
+
+func (conn *connLogger) close(depth int) {
+	conn.once.Do(func() { conn.log(depth+3, "closing") })
+}
+
+func (conn *connLogger) log(depth int, event string) {
+	raddr := conn.RemoteAddr()
+	laddr := conn.LocalAddr()
+
+	// Here we're doing our best to get adjust the call depth to point outside
+	// of this package, but if the connection is wrapped again it may not be
+	// very meaningful to report the file/line from which the connection was
+	// handled or closed.
+	logger := *conn.Logger
+	logger.CallDepth += depth + 1
+
+	logger.Log("%{local_address}s->%{remote_address}s - %{event}s %{type}s %{protocol}s connection",
+		laddr.String(),
+		raddr.String(),
+		event,
+		conn.typ,
+		laddr.Network(),
+	)
+}

--- a/netevents/conn.go
+++ b/netevents/conn.go
@@ -31,7 +31,7 @@ func (conn *connLogger) log(depth int, event string) {
 	raddr := conn.RemoteAddr()
 	laddr := conn.LocalAddr()
 
-	// Here we're doing our best to get adjust the call depth to point outside
+	// Here we're doing our best to adjust the call depth to point outside
 	// of this package, but if the connection is wrapped again it may not be
 	// very meaningful to report the file/line from which the connection was
 	// handled or closed.

--- a/netevents/conn_test.go
+++ b/netevents/conn_test.go
@@ -1,0 +1,31 @@
+package netevents
+
+import (
+	"net"
+	"time"
+)
+
+type mockConn struct {
+	laddr mockAddr
+	raddr mockAddr
+}
+
+func (c mockConn) Close() error { return nil }
+
+func (c mockConn) Read(b []byte) (int, error)  { return 0, nil }
+func (c mockConn) Write(b []byte) (int, error) { return len(b), nil }
+
+func (c mockConn) SetDeadline(t time.Time) error      { return nil }
+func (c mockConn) SetReadDeadline(t time.Time) error  { return nil }
+func (c mockConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func (c mockConn) LocalAddr() net.Addr  { return c.laddr }
+func (c mockConn) RemoteAddr() net.Addr { return c.raddr }
+
+type mockAddr struct {
+	s string
+	n string
+}
+
+func (a mockAddr) String() string  { return a.s }
+func (a mockAddr) Network() string { return a.n }

--- a/netevents/dial.go
+++ b/netevents/dial.go
@@ -3,6 +3,7 @@ package netevents
 import (
 	"context"
 	"net"
+	"runtime"
 
 	"github.com/segmentio/events"
 )
@@ -41,6 +42,9 @@ func dialContextFunc(depth int, logger *events.Logger, dial func(context.Context
 			c := &connLogger{Conn: conn, Logger: logger, typ: "client"}
 			c.open(depth + 1)
 			conn = c
+			// Ensure the connection emits a close event if it's closed by the
+			// garbage collector.
+			runtime.SetFinalizer(c, func(c *connLogger) { c.close(0) })
 		}
 		return
 	}

--- a/netevents/dial.go
+++ b/netevents/dial.go
@@ -1,0 +1,47 @@
+package netevents
+
+import (
+	"context"
+	"net"
+
+	"github.com/segmentio/events"
+)
+
+// DialFunc returns a wrapper for dial which logs opening and closing events
+// that occur on the connections returned by the function.
+//
+// The logger may be nil, in that case the default logger is used to report
+// the connection events.
+func DialFunc(logger *events.Logger, dial func(string, string) (net.Conn, error)) func(string, string) (net.Conn, error) {
+	dialContext := dialContextFunc(1, logger,
+		func(ctx context.Context, network string, address string) (net.Conn, error) {
+			return dial(network, address)
+		},
+	)
+	return func(network string, address string) (net.Conn, error) {
+		return dialContext(context.Background(), network, address)
+	}
+}
+
+// DialContextFunc returns a wrapper for dial which logs opening and closing
+// events that occur on the connections returned by the function.
+//
+// The logger may be nil, in that case the default logger is used to report
+// the connection events.
+func DialContextFunc(logger *events.Logger, dial func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {
+	return dialContextFunc(0, logger, dial)
+}
+
+func dialContextFunc(depth int, logger *events.Logger, dial func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {
+	if logger == nil {
+		logger = events.DefaultLogger
+	}
+	return func(ctx context.Context, network string, address string) (conn net.Conn, err error) {
+		if conn, err = dial(ctx, network, address); err == nil {
+			c := &connLogger{Conn: conn, Logger: logger, typ: "client"}
+			c.open(depth + 1)
+			conn = c
+		}
+		return
+	}
+}

--- a/netevents/dial_test.go
+++ b/netevents/dial_test.go
@@ -1,0 +1,73 @@
+package netevents
+
+import (
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/segmentio/events"
+)
+
+func TestDialFunc(t *testing.T) {
+	evList := []*events.Event{}
+	logger := events.NewLogger(events.HandlerFunc(func(e *events.Event) {
+		evList = append(evList, e.Clone())
+	}))
+
+	dial := DialFunc(logger, func(network string, address string) (net.Conn, error) {
+		return mockConn{
+			laddr: mockAddr{"127.0.0.1:56789", network},
+			raddr: mockAddr{address, network},
+		}, nil
+	})
+
+	conn, err := dial("tcp", "127.0.0.1:80")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	conn.Close()
+
+	if len(evList) != 2 {
+		t.Error("bad event count:", len(evList))
+		return
+	}
+
+	e1 := *evList[0]
+	e2 := *evList[1]
+
+	t.Logf("%#v", e1)
+	t.Logf("%#v", e2)
+
+	e1.Source = ""
+	e2.Source = ""
+	e1.Time = time.Time{}
+	e2.Time = time.Time{}
+
+	if !reflect.DeepEqual(e1, events.Event{
+		Message: "127.0.0.1:56789->127.0.0.1:80 - opening client tcp connection",
+		Args: events.Args{
+			{"local_address", "127.0.0.1:56789"},
+			{"remote_address", "127.0.0.1:80"},
+			{"event", "opening"},
+			{"type", "client"},
+			{"protocol", "tcp"},
+		},
+	}) {
+		t.Error("bad opening event")
+	}
+
+	if !reflect.DeepEqual(e2, events.Event{
+		Message: "127.0.0.1:56789->127.0.0.1:80 - closing client tcp connection",
+		Args: events.Args{
+			{"local_address", "127.0.0.1:56789"},
+			{"remote_address", "127.0.0.1:80"},
+			{"event", "closing"},
+			{"type", "client"},
+			{"protocol", "tcp"},
+		},
+	}) {
+		t.Error("bad closing event")
+	}
+}

--- a/netevents/handler.go
+++ b/netevents/handler.go
@@ -1,0 +1,26 @@
+package netevents
+
+import (
+	"context"
+	"net"
+
+	"github.com/segmentio/events"
+	"github.com/segmentio/netx"
+)
+
+// NewHandler returns a wrapper for handler which logs opening and closing
+// events that occur on the connections served by the handler with logger.
+//
+// The logger may be nil, in that case the default logger is used to report
+// the connection events.
+func NewHandler(logger *events.Logger, handler netx.Handler) netx.Handler {
+	if logger == nil {
+		logger = events.DefaultLogger
+	}
+	return netx.HandlerFunc(func(ctx context.Context, conn net.Conn) {
+		c := &connLogger{Conn: conn, Logger: logger, typ: "server"}
+		c.open(2)
+		defer c.close(2) // ensure we always log the close event
+		handler.ServeConn(ctx, c)
+	})
+}

--- a/netevents/handler_test.go
+++ b/netevents/handler_test.go
@@ -1,0 +1,70 @@
+package netevents
+
+import (
+	"context"
+	"net"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/segmentio/events"
+	"github.com/segmentio/netx"
+)
+
+func TestHandler(t *testing.T) {
+	evList := []*events.Event{}
+	logger := events.NewLogger(events.HandlerFunc(func(e *events.Event) {
+		evList = append(evList, e.Clone())
+	}))
+
+	handler := NewHandler(logger, netx.HandlerFunc(func(ctx context.Context, conn net.Conn) {
+		conn.Close()
+	}))
+
+	handler.ServeConn(context.Background(), mockConn{
+		laddr: mockAddr{"127.0.0.1:80", "tcp"},
+		raddr: mockAddr{"127.0.0.1:56789", "tcp"},
+	})
+
+	if len(evList) != 2 {
+		t.Error("bad event count:", len(evList))
+		return
+	}
+
+	e1 := *evList[0]
+	e2 := *evList[1]
+
+	t.Logf("%#v", e1)
+	t.Logf("%#v", e2)
+
+	e1.Source = ""
+	e2.Source = ""
+	e1.Time = time.Time{}
+	e2.Time = time.Time{}
+
+	if !reflect.DeepEqual(e1, events.Event{
+		Message: "127.0.0.1:80->127.0.0.1:56789 - opening server tcp connection",
+		Args: events.Args{
+			{"local_address", "127.0.0.1:80"},
+			{"remote_address", "127.0.0.1:56789"},
+			{"event", "opening"},
+			{"type", "server"},
+			{"protocol", "tcp"},
+		},
+	}) {
+		t.Error("bad opening event")
+	}
+
+	if !reflect.DeepEqual(e2, events.Event{
+		Message: "127.0.0.1:80->127.0.0.1:56789 - closing server tcp connection",
+		Args: events.Args{
+			{"local_address", "127.0.0.1:80"},
+			{"remote_address", "127.0.0.1:56789"},
+			{"event", "closing"},
+			{"type", "server"},
+			{"protocol", "tcp"},
+		},
+	}) {
+		t.Error("bad closing event")
+	}
+}


### PR DESCRIPTION
@yields 
@f2prateek 

Here are implementations of other wrappers for automatically generating open/close events at the connection level.

I also tuned the `httpevents` handler log line so both the net and http events have the same prefixes when they come from the same connections (`local_address->remote_address`).

Please take a look and let me know if something should be changed.