### PR TITLE
Http transport

### DIFF
--- a/httpevents/handler.go
+++ b/httpevents/handler.go
@@ -29,7 +29,7 @@ func NewHandler(logger *events.Logger, handler http.Handler) http.Handler {
 			// We capture all the values we need from req in case the object
 			// gets modified by the handler.
 			logger:  logger,
-			request: makeRequest(req),
+			request: makeRequest(req, laddr),
 		}
 
 		// If the handler panics we want to make sure we report the issue in the

--- a/httpevents/handler.go
+++ b/httpevents/handler.go
@@ -28,15 +28,8 @@ func NewHandler(logger *events.Logger, handler http.Handler) http.Handler {
 			ResponseWriter: res,
 			// We capture all the values we need from req in case the object
 			// gets modified by the handler.
-			logger:   logger,
-			laddr:    laddr,
-			raddr:    req.RemoteAddr,
-			method:   req.Method,
-			host:     req.Host,
-			path:     req.URL.Path,
-			query:    req.URL.RawQuery,
-			fragment: req.URL.Fragment,
-			agent:    req.UserAgent(),
+			logger:  logger,
+			request: makeRequest(req),
 		}
 
 		// If the handler panics we want to make sure we report the issue in the
@@ -62,49 +55,15 @@ func NewHandler(logger *events.Logger, handler http.Handler) http.Handler {
 
 type responseWriter struct {
 	http.ResponseWriter
-	logger   *events.Logger
-	laddr    string
-	raddr    string
-	method   string
-	host     string
-	path     string
-	query    string
-	fragment string
-	agent    string
+	logger *events.Logger
+	request
 }
 
 func (w *responseWriter) WriteHeader(status int) {
-	if w.logger != nil {
-		var buf [128]byte
-		var fmt = append(buf[:0], "%{local_address}s->%{remote_address}s - %{host}s - %{method}s %{path}s"...)
-
-		// Don't output a '?' character when the query string is empty, this is
-		// a more natural way of reading URLs.
-		if len(w.query) != 0 {
-			fmt = append(fmt, '?')
-		}
-		fmt = append(fmt, "%{query}s"...)
-
-		// Same than with the query string, don't output a '#' character when
-		// there is no fragment.
-		if len(w.fragment) != 0 {
-			fmt = append(fmt, '#')
-		}
-		fmt = append(fmt, "%{fragment}s - %{status}d %s - %{agent}q"...)
-
-		w.logger.Log(string(fmt),
-			w.laddr,
-			w.raddr,
-			w.host,
-			w.method,
-			w.path,
-			w.query,
-			w.fragment,
-			status,
-			http.StatusText(status),
-			w.agent,
-		)
+	if logger := w.logger; logger != nil {
 		w.logger = nil
+		w.status = status
+		w.log(logger, 1)
 	}
 	w.ResponseWriter.WriteHeader(status)
 }

--- a/httpevents/request.go
+++ b/httpevents/request.go
@@ -21,6 +21,10 @@ type request struct {
 func makeRequest(req *http.Request, laddr string) request {
 	var raddr string
 
+	if len(laddr) == 0 {
+		laddr = "???"
+	}
+
 	if raddr = req.RemoteAddr; len(raddr) == 0 {
 		raddr = "???"
 	}

--- a/httpevents/request.go
+++ b/httpevents/request.go
@@ -21,10 +21,8 @@ type request struct {
 func makeRequest(req *http.Request, laddr string) request {
 	var raddr string
 
-	if len(req.RemoteAddr) == 0 {
-		raddr = req.URL.Host
-	} else {
-		raddr = req.RemoteAddr
+	if raddr = req.RemoteAddr; len(raddr) == 0 {
+		raddr = "???"
 	}
 
 	return request{

--- a/httpevents/request.go
+++ b/httpevents/request.go
@@ -1,0 +1,66 @@
+package httpevents
+
+import (
+	"net/http"
+
+	"github.com/segmentio/events"
+)
+
+type request struct {
+	address  string
+	method   string
+	host     string
+	path     string
+	query    string
+	fragment string
+	agent    string
+	status   int
+}
+
+func makeRequest(req *http.Request) request {
+	return request{
+		address:  req.RemoteAddr,
+		method:   req.Method,
+		host:     req.Host,
+		path:     req.URL.Path,
+		query:    req.URL.RawQuery,
+		fragment: req.URL.Fragment,
+		agent:    req.UserAgent(),
+	}
+}
+
+func (r *request) log(logger *events.Logger, depth int) {
+	var l = *logger
+	var b [128]byte
+
+	l.CallDepth = depth + 1
+	l.Log(string(r.appendLogFormat(b[:0])),
+		r.address,
+		r.host,
+		r.method,
+		r.path,
+		r.query,
+		r.fragment,
+		r.status,
+		http.StatusText(r.status),
+		r.agent,
+	)
+}
+
+func (r *request) appendLogFormat(b []byte) []byte {
+	b = append(b, "%{address}s - %{host}s - %{method}s %{path}s"...)
+
+	// Don't output a '?' character when the query string is empty, this is
+	// a more natural way of reading URLs.
+	if len(r.query) != 0 {
+		b = append(b, '?')
+	}
+	b = append(b, "%{query}s"...)
+
+	// Same than with the query string, don't output a '#' character when
+	// there is no fragment.
+	if len(r.fragment) != 0 {
+		b = append(b, '#')
+	}
+	return append(b, "%{fragment}s - %{status}d %s - %{agent}q"...)
+}

--- a/httpevents/transport.go
+++ b/httpevents/transport.go
@@ -1,0 +1,32 @@
+package httpevents
+
+import (
+	"net/http"
+
+	"github.com/segmentio/events"
+)
+
+// NewTransport wraps the HTTP transport and returns a new RoundTripper which
+// logs all submitted requests with logger.
+func NewTransport(logger *events.Logger, transport http.RoundTripper) http.RoundTripper {
+	if logger == nil {
+		logger = events.DefaultLogger
+	}
+	return roundTripperFunc(func(req *http.Request) (res *http.Response, err error) {
+		//r := makeRequest(req)
+
+		if res, err = transport.RoundTrip(req); err != nil {
+
+		} else {
+
+		}
+
+		return
+	})
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/httpevents/transport_test.go
+++ b/httpevents/transport_test.go
@@ -1,0 +1,73 @@
+package httpevents
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/segmentio/events"
+)
+
+func TestTransport(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusOK)
+		res.Write([]byte("Hello World!"))
+	}))
+	defer server.Close()
+
+	evList := []*events.Event{}
+	logger := events.NewLogger(events.HandlerFunc(func(e *events.Event) {
+		evList = append(evList, e.Clone())
+	}))
+
+	transport := NewTransport(logger, http.DefaultTransport)
+
+	req := httptest.NewRequest("GET", server.URL+"/", nil)
+	req.Header.Set("User-Agent", "httpevents")
+
+	res, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if s := string(b); s != "Hello World!" {
+		t.Error("bad response:", s)
+	}
+
+	if len(evList) != 1 {
+		t.Error("bad event count:", evList)
+		return
+	}
+
+	e := *evList[0]
+	e.Source = ""
+	e.Time = time.Time{}
+
+	if !reflect.DeepEqual(e, events.Event{
+		Message: fmt.Sprintf(`*->192.0.2.1:1234 - %s - GET / - 200 OK - "httpevents"`, req.Host),
+		Args: events.Args{
+			{"local_address", "*"},
+			{"remote_address", "192.0.2.1:1234"},
+			{"host", req.Host},
+			{"method", "GET"},
+			{"path", "/"},
+			{"query", ""},
+			{"fragment", ""},
+			{"status", 200},
+			{"agent", "httpevents"},
+		},
+	}) {
+		t.Errorf("%#v", e)
+	}
+}


### PR DESCRIPTION
@yields 
@f2prateek 

I added another wrapper for getting request logs on the client side, here's an example of how it can be used:
```go
// Wraps the default transport so it emits events on the default logger.
http.DefaultTransport = httpevents.NewTransport(nil, http.DefaultTransport)
```
The events have the same structure than the ones generated on the request handler, the only difference is the local address is `*` because it cannot be predicted (the transport abstracts away the connections it uses).

Please take a look and let me know if something should be changed.