### PR TITLE
add text.Handler.EnableArgs

### DIFF
--- a/text/handler_test.go
+++ b/text/handler_test.go
@@ -11,25 +11,46 @@ import (
 )
 
 func TestHandler(t *testing.T) {
-	b := &bytes.Buffer{}
-	h := NewHandler("==> ", b)
-	h.EnableArgs = true
-
-	h.HandleEvent(&events.Event{
-		Message: "Hello Luke!",
-		Source:  "github.com/segmentio/events/text/handler_test.go:18",
-		Args:    events.Args{{"name", "Luke"}, {"from", "Han"}, {"error", io.EOF}},
-		Time:    time.Date(2017, 1, 1, 23, 42, 0, 123000000, time.Local),
-		Debug:   true,
-	})
-
-	if s := b.String(); s != `==> 2017-01-01 23:42:00.123 - github.com/segmentio/events/text/handler_test.go:18 - Hello Luke!
+	tests := []struct {
+		name   string
+		args   bool
+		output string
+	}{
+		{
+			name: "EnableArgs:true",
+			args: true,
+			output: `==> 2017-01-01 23:42:00.123 - github.com/segmentio/events/text/handler_test.go:18 - Hello Luke!
 	name: Luke
 	from: Han
 	errors:
 		- EOF
-` {
-		t.Error(s)
+`,
+		},
+		{
+			name:   "EnableArgs:false",
+			args:   false,
+			output: "==> 2017-01-01 23:42:00.123 - github.com/segmentio/events/text/handler_test.go:18 - Hello Luke!\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b := &bytes.Buffer{}
+			h := NewHandler("==> ", b)
+			h.EnableArgs = test.args
+
+			h.HandleEvent(&events.Event{
+				Message: "Hello Luke!",
+				Source:  "github.com/segmentio/events/text/handler_test.go:18",
+				Args:    events.Args{{"name", "Luke"}, {"from", "Han"}, {"error", io.EOF}},
+				Time:    time.Date(2017, 1, 1, 23, 42, 0, 123000000, time.Local),
+				Debug:   true,
+			})
+
+			if s := b.String(); s != test.output {
+				t.Error(s)
+			}
+		})
 	}
 }
 

--- a/text/handler_test.go
+++ b/text/handler_test.go
@@ -13,6 +13,7 @@ import (
 func TestHandler(t *testing.T) {
 	b := &bytes.Buffer{}
 	h := NewHandler("==> ", b)
+	h.EnableArgs = true
 
 	h.HandleEvent(&events.Event{
 		Message: "Hello Luke!",


### PR DESCRIPTION
@f2prateek 

Follow up of our earlier conversation, add a way to control the output of the text handler that doesn't depend on how the events were generated.