### PR TITLE
add DefaultPrefix

### DIFF
--- a/text/init.go
+++ b/text/init.go
@@ -1,14 +1,24 @@
 package text
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/segmentio/events"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+// DefaultPrefix is used by the default handler configured when the program's
+// standard output is a terminal.
+//
+// The value is "program-name[pid]: "
+var DefaultPrefix string
+
 func init() {
+	DefaultPrefix = fmt.Sprintf("%s[%d]: ", filepath.Base(os.Args[0]), os.Getpid())
+
 	if terminal.IsTerminal(1) {
-		events.DefaultHandler = NewHandler("", os.Stdout)
+		events.DefaultHandler = NewHandler(DefaultPrefix, os.Stdout)
 	}
 }


### PR DESCRIPTION
@f2prateek 

The idea here is to make the default more useful by outputting the program name and PID in the text handler.
I'm working on a program that spawns sub-processes and having this is really valuable to differentiate which program logs are coming from.