### PR TITLE
add program and pid to ecslogs handler

### DIFF
--- a/ecslogs/handler.go
+++ b/ecslogs/handler.go
@@ -20,7 +20,9 @@ import (
 //
 // It is safe to use a handler concurrently from multiple goroutines.
 type Handler struct {
-	Output io.Writer
+	Output  io.Writer
+	Program string
+	Pid     int
 }
 
 // NewHandler creates a new handler which writes to output
@@ -41,6 +43,8 @@ func (h *Handler) HandleEvent(e *events.Event) {
 	f.message = e.Message
 	f.data.args = e.Args
 	f.info.Source = e.Source
+	f.info.Program = h.Program
+	f.info.Pid = h.Pid
 
 	if e.Debug {
 		f.level = "DEBUG"
@@ -71,8 +75,10 @@ type event struct {
 }
 
 type eventInfo struct {
-	Source string       `objconv:"source,omitempty"`
-	Errors []eventError `objconv:"errors,omitempty"`
+	Program string       `objconv:"program,omitempty"`
+	Source  string       `objconv:"source,omitempty"`
+	Pid     int          `objconv:"pid,omitempty"`
+	Errors  []eventError `objconv:"errors,omitempty"`
 }
 
 type eventError struct {

--- a/ecslogs/init.go
+++ b/ecslogs/init.go
@@ -2,6 +2,7 @@ package ecslogs
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/segmentio/events"
 	"golang.org/x/crypto/ssh/terminal"
@@ -9,6 +10,10 @@ import (
 
 func init() {
 	if !terminal.IsTerminal(1) {
-		events.DefaultHandler = NewHandler(os.Stdout)
+		events.DefaultHandler = &Handler{
+			Output:  os.Stdout,
+			Program: filepath.Base(os.Args[0]),
+			Pid:     os.Getpid(),
+		}
 	}
 }


### PR DESCRIPTION
@f2prateek 

Follow up of #9, same idea with the ecslogs handler, getting the program and pid is good to differentiate where a log came from when there are multiple processes writing to the same output.