### PR TITLE
add sigevents package

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,3 +21,4 @@ test:
       --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest
+      go.test='govendor test -v -race -cover +local && go test -v -cover -run TestSignalHandler ./sigevents'

--- a/sigevents/doc.go
+++ b/sigevents/doc.go
@@ -1,0 +1,3 @@
+// Package sigevents installs signal handlers for SIGUSR1 and SIGUSR2, enabling
+// debug logs when the former is received, or disabling them on the latter.
+package sigevents

--- a/sigevents/init.go
+++ b/sigevents/init.go
@@ -26,7 +26,6 @@ func run(signals <-chan os.Signal) {
 		switch sig {
 		case syscall.SIGUSR1:
 			events.DefaultLogger.EnableDebug = true
-
 		case syscall.SIGUSR2:
 			events.DefaultLogger.EnableDebug = false
 		}

--- a/sigevents/init.go
+++ b/sigevents/init.go
@@ -1,0 +1,34 @@
+package sigevents
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/segmentio/events"
+)
+
+func init() {
+	sigchan := make(chan os.Signal, 1)
+	sigrecv := events.Signal(sigchan)
+	signal.Notify(sigchan, syscall.SIGUSR1, syscall.SIGUSR2)
+
+	go run(sigrecv)
+}
+
+func run(signals <-chan os.Signal) {
+	// This may be seen as a race between this goroutine and the ones reading
+	// the value of the EnableDebug field but in practice it doesn't matter.
+	// We only care about eventual consistency here which will happen once the
+	// caches of the various CPUs synchronize and will result in all debug logs
+	// being enabled or disabled.
+	for sig := range signals {
+		switch sig {
+		case syscall.SIGUSR1:
+			events.DefaultLogger.EnableDebug = true
+
+		case syscall.SIGUSR2:
+			events.DefaultLogger.EnableDebug = false
+		}
+	}
+}

--- a/sigevents/init_test.go
+++ b/sigevents/init_test.go
@@ -1,0 +1,32 @@
+package sigevents
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/segmentio/events"
+)
+
+func TestSignalHandler(t *testing.T) {
+	p, _ := os.FindProcess(os.Getpid())
+	p.Signal(syscall.SIGUSR1)
+	p.Signal(syscall.SIGUSR1)
+
+	// wait for signals to be processed, this is an asynchronous operation
+	time.Sleep(10 * time.Millisecond)
+
+	if !events.DefaultLogger.EnableDebug {
+		t.Error("debug logs should be enabled after receiving SIGUSR1")
+	}
+
+	p.Signal(syscall.SIGUSR2)
+
+	// wait for signals to be processed, this is an asynchronous operation
+	time.Sleep(10 * time.Millisecond)
+
+	if events.DefaultLogger.EnableDebug {
+		t.Error("debug logs should not be enabled after receiving SIGUSR2")
+	}
+}

--- a/sigevents/init_test.go
+++ b/sigevents/init_test.go
@@ -1,3 +1,5 @@
+// +build !race
+
 package sigevents
 
 import (


### PR DESCRIPTION
Follow up of our discussion on the stats package, here's the quick implementation of a package that when imported, adds handlers for SIGUSR1 and SIGUSR2 which enable or disable debug logs.