### PR TITLE
drop terminal dependency

### DIFF
--- a/ecslogs/init.go
+++ b/ecslogs/init.go
@@ -5,11 +5,10 @@ import (
 	"path/filepath"
 
 	"github.com/segmentio/events"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 func init() {
-	if !terminal.IsTerminal(1) {
+	if !events.IsTerminal(1) {
 		events.DefaultHandler = &Handler{
 			Output:  os.Stdout,
 			Program: filepath.Base(os.Args[0]),

--- a/log/log.go
+++ b/log/log.go
@@ -6,8 +6,6 @@ import (
 	"log"
 	"os"
 
-	"golang.org/x/crypto/ssh/terminal"
-
 	"github.com/segmentio/events"
 	"github.com/segmentio/events/ecslogs"
 	"github.com/segmentio/events/text"
@@ -41,7 +39,7 @@ func NewHandler(w io.Writer) events.Handler {
 	if f, ok := w.(interface {
 		Fd() uintptr
 	}); ok {
-		term = terminal.IsTerminal(int(f.Fd()))
+		term = events.IsTerminal(int(f.Fd()))
 	}
 
 	if term {

--- a/terminal.go
+++ b/terminal.go
@@ -1,0 +1,19 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd linux,!appengine netbsd openbsd
+
+package events
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	var termios syscall.Termios
+	_, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), ioctlReadTermios, uintptr(unsafe.Pointer(&termios)), 0, 0, 0)
+	return err == 0
+}

--- a/terminal_bsd.go
+++ b/terminal_bsd.go
@@ -1,0 +1,12 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package events
+
+import "syscall"
+
+const ioctlReadTermios = syscall.TIOCGETA
+const ioctlWriteTermios = syscall.TIOCSETA

--- a/terminal_linux.go
+++ b/terminal_linux.go
@@ -1,0 +1,11 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package events
+
+// These constants are declared here, rather than importing
+// them from the syscall package as some syscall packages, even
+// on linux, for example gccgo, do not declare them.
+const ioctlReadTermios = 0x5401  // syscall.TCGETS
+const ioctlWriteTermios = 0x5402 // syscall.TCSETS

--- a/terminal_plan9.go
+++ b/terminal_plan9.go
@@ -1,0 +1,10 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package events
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	return false
+}

--- a/terminal_windows.go
+++ b/terminal_windows.go
@@ -1,0 +1,48 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package events
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var kernel32 = syscall.NewLazyDLL("kernel32.dll")
+
+var (
+	procGetConsoleMode = kernel32.NewProc("GetConsoleMode")
+)
+
+type (
+	short int16
+	word  uint16
+
+	coord struct {
+		x short
+		y short
+	}
+	smallRect struct {
+		left   short
+		top    short
+		right  short
+		bottom short
+	}
+	consoleScreenBufferInfo struct {
+		size              coord
+		cursorPosition    coord
+		attributes        word
+		window            smallRect
+		maximumWindowSize coord
+	}
+)
+
+// IsTerminal returns true if the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	var st uint32
+	r, _, e := syscall.Syscall(procGetConsoleMode.Addr(), 2, uintptr(fd), uintptr(unsafe.Pointer(&st)), 0)
+	return r != 0 && e == 0
+}

--- a/text/init.go
+++ b/text/init.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/segmentio/events"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 // DefaultPrefix is used by the default handler configured when the program's
@@ -18,7 +17,7 @@ var DefaultPrefix string
 func init() {
 	DefaultPrefix = fmt.Sprintf("%s[%d]: ", filepath.Base(os.Args[0]), os.Getpid())
 
-	if terminal.IsTerminal(1) {
+	if events.IsTerminal(1) {
 		events.DefaultHandler = NewHandler(DefaultPrefix, os.Stdout)
 	}
 }


### PR DESCRIPTION
Got tired of having to vendor the millions of files for golang.org/x/sys/unix in every project because github.com/golang/crypto/ssh/terminal depends on it... 