### PR TITLE
drop github.com/segmentio/netx dependency

### DIFF
--- a/netevents/dial.go
+++ b/netevents/dial.go
@@ -29,7 +29,7 @@ func DialFuncWith(logger *events.Logger, dial func(string, string) (net.Conn, er
 	}
 }
 
-// DialContextFuncWith returns a wrapper for dial which logs with the default
+// DialContextFunc returns a wrapper for dial which logs with the default
 // logger all opening and closing events that occur on the connections returned
 // by the dial function.
 func DialContextFunc(dial func(context.Context, string, string) (net.Conn, error)) func(context.Context, string, string) (net.Conn, error) {

--- a/netevents/handler.go
+++ b/netevents/handler.go
@@ -5,24 +5,47 @@ import (
 	"net"
 
 	"github.com/segmentio/events"
-	"github.com/segmentio/netx"
 )
+
+// Handler is an interface that can be implemented by types that serve network
+// connections.
+type Handler interface {
+	ServeConn(ctx context.Context, conn net.Conn)
+}
 
 // NewHandler returns a wrapped handler which logs with the default logger
 // all opening and closing events that occur on the connections servied by the
 // handler.
-func NewHandler(handler netx.Handler) netx.Handler {
+func NewHandler(handler Handler) Handler {
 	return NewHandlerWith(events.DefaultLogger, handler)
 }
 
 // NewHandlerWith returns a wrapped handler which logs with logger all
 // opening and closing events that occur on the connections served by the
 // handler with logger.
-func NewHandlerWith(logger *events.Logger, handler netx.Handler) netx.Handler {
-	return netx.HandlerFunc(func(ctx context.Context, conn net.Conn) {
-		c := &connLogger{Conn: conn, Logger: logger, typ: "server"}
-		c.open(2)
-		defer c.close(2) // ensure we always log the close event
-		handler.ServeConn(ctx, c)
-	})
+func NewHandlerWith(logger *events.Logger, handler Handler) Handler {
+	if logger == nil {
+		panic("cannot send network events to a nil logger")
+	}
+
+	if handler == nil {
+		panic("cannot capture network events of a nil handler")
+	}
+
+	return &handlerLogger{
+		Handler: handler,
+		Logger:  logger,
+	}
+}
+
+type handlerLogger struct {
+	Handler
+	*events.Logger
+}
+
+func (h *handlerLogger) ServeConn(ctx context.Context, conn net.Conn) {
+	c := &connLogger{Conn: conn, Logger: h.Logger, typ: "server"}
+	c.open(2)
+	defer c.close(2) // ensure we always log the close event
+	h.Handler.ServeConn(ctx, c)
 }

--- a/netevents/handler_test.go
+++ b/netevents/handler_test.go
@@ -8,8 +8,13 @@ import (
 	"time"
 
 	"github.com/segmentio/events"
-	"github.com/segmentio/netx"
 )
+
+type testHandler struct{}
+
+func (*testHandler) ServeConn(ctx context.Context, conn net.Conn) {
+	conn.Close()
+}
 
 func TestHandler(t *testing.T) {
 	evList := []*events.Event{}
@@ -17,9 +22,7 @@ func TestHandler(t *testing.T) {
 		evList = append(evList, e.Clone())
 	}))
 
-	handler := NewHandlerWith(logger, netx.HandlerFunc(func(ctx context.Context, conn net.Conn) {
-		conn.Close()
-	}))
+	handler := NewHandlerWith(logger, &testHandler{})
 
 	handler.ServeConn(context.Background(), mockConn{
 		laddr: mockAddr{"127.0.0.1:80", "tcp"},


### PR DESCRIPTION
This pull request drops the dependency on github.com/segmentio/netx, that package was mostly experimental stuff and I don't wanna maintain it, and contains tons of stuff that aren't used here.