### PR TITLE
test unsafe crash

### DIFF
--- a/event_safe.go
+++ b/event_safe.go
@@ -9,7 +9,3 @@ func cloneValue(v interface{}) interface{} {
 func bytesToString(b []byte) string {
 	return string(b)
 }
-
-func noescape(a []interface{}) []interface{} {
-	return a
-}

--- a/event_unsafe.go
+++ b/event_unsafe.go
@@ -28,12 +28,3 @@ func bytesToString(b []byte) string {
 		Len:  len(b),
 	}))
 }
-
-func noescape(a []interface{}) (b []interface{}) {
-	// The use of reflect.SliceHeader tricks the compiler into thinking that the
-	// content of the input slice doesn't escape, so we can prevent dynamic
-	// memory allocations that would otherwise happen for each argument of a log
-	// message.
-	*(*reflect.SliceHeader)(unsafe.Pointer(&b)) = *(*reflect.SliceHeader)(unsafe.Pointer(&a))
-	return
-}

--- a/httpevents/request_unsafe.go
+++ b/httpevents/request_unsafe.go
@@ -14,18 +14,18 @@ func bytesToStringNonEmpty(b []byte) string {
 	}))
 }
 
-func convS2E(s *string) (v interface{}) {
-	e := (*eface)(unsafe.Pointer(&v))
-	e.t = stringType
-	e.v = unsafe.Pointer(s)
-	return
+func convS2E(s *string) interface{} {
+	return *(*interface{})(unsafe.Pointer(&eface{
+		t: stringType,
+		v: unsafe.Pointer(s),
+	}))
 }
 
-func convI2E(i *int) (v interface{}) {
-	e := (*eface)(unsafe.Pointer(&v))
-	e.t = intType
-	e.v = unsafe.Pointer(i)
-	return
+func convI2E(i *int) interface{} {
+	return *(*interface{})(unsafe.Pointer(&eface{
+		t: intType,
+		v: unsafe.Pointer(i),
+	}))
 }
 
 type eface struct {


### PR DESCRIPTION
I spotted an issue with a misuse of unsafe, this PR adds a test that reproduces pretty consistently the issue (except on the Circle CI run apparently), here's the trace:
```
$ CGO_ENABLED=0 GODEBUG=gccheckmark=1 GOTRACEBACK=crash GOGC=1 go test -v
=== RUN   TestEvent
=== RUN   TestEvent/Clone
--- PASS: TestEvent (0.00s)
    --- PASS: TestEvent/Clone (0.00s)
=== RUN   TestArgs
=== RUN   TestArgs/Get
=== RUN   TestArgs/Map
--- PASS: TestArgs (0.00s)
    --- PASS: TestArgs/Get (0.00s)
    --- PASS: TestArgs/Map (0.00s)
=== RUN   TestUnsafe
runtime: pointer 0xc4209e5f90 to unallocated span idx=0x4f2 span.base()=0xc4206da000 span.limit=0xc4208da000 span.state=3
runtime: found in object at *(0xc420046600+0x18)
object=0xc420046600 k=0x6210023 s.base()=0xc420046000 s.limit=0xc420048000 s.sizeclass=17 s.elemsize=256 s.state=_MSpanInUse
 *(object+0) = 0x1156396
 *(object+8) = 0x4
 *(object+16) = 0x111d040
 *(object+24) = 0xc4209e5f90 <==
 *(object+32) = 0x11563a3
 *(object+40) = 0x2
 *(object+48) = 0x111d040
 *(object+56) = 0xc4209e5f80
 *(object+64) = 0x0
 *(object+72) = 0x0
 *(object+80) = 0x0
 *(object+88) = 0x0
 *(object+96) = 0x0
...
```