### PR TITLE
Fix unsafe crash

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,4 +21,4 @@ test:
       --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest
-      go.test='govendor test -v -race -cover +local && go test -v -cover -run TestSignalHandler ./sigevents'
+      go.test='CGO_ENABLED=0 GODEBUG=gccheckmark=1 GOTRACEBACK=crash GOGC=1 govendor test -v -race -cover +local && go test -v -cover -run TestSignalHandler ./sigevents'

--- a/circle.yml
+++ b/circle.yml
@@ -21,4 +21,4 @@ test:
       --volume ${PWD}:/go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       --workdir /go/src/github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}
       segment/golang:latest
-      go.test='CGO_ENABLED=0 GODEBUG=gccheckmark=1 GOTRACEBACK=crash GOGC=1 govendor test -v -race -cover +local && go test -v -cover -run TestSignalHandler ./sigevents'
+      go.test='govendor test -v -race -cover +local && go test -v -cover -run TestSignalHandler ./sigevents'

--- a/event_safe.go
+++ b/event_safe.go
@@ -10,6 +10,6 @@ func bytesToString(b []byte) string {
 	return string(b)
 }
 
-func noescape(a []interface{}) []interface{} {
-	return a
+func noescape(v interface{}) interface{} {
+	return v
 }

--- a/event_safe.go
+++ b/event_safe.go
@@ -9,7 +9,3 @@ func cloneValue(v interface{}) interface{} {
 func bytesToString(b []byte) string {
 	return string(b)
 }
-
-func noescape(v interface{}) interface{} {
-	return v
-}

--- a/event_unsafe.go
+++ b/event_unsafe.go
@@ -28,9 +28,3 @@ func bytesToString(b []byte) string {
 		Len:  len(b),
 	}))
 }
-
-func noescape(v interface{}) (u interface{}) {
-	type eface [2]uintptr
-	*(*eface)(unsafe.Pointer(&u)) = *(*eface)(unsafe.Pointer(&v))
-	return
-}

--- a/event_unsafe.go
+++ b/event_unsafe.go
@@ -29,11 +29,8 @@ func bytesToString(b []byte) string {
 	}))
 }
 
-func noescape(a []interface{}) (b []interface{}) {
-	// The use of reflect.SliceHeader tricks the compiler into thinking that the
-	// content of the input slice doesn't escape, so we can prevent dynamic
-	// memory allocations that would otherwise happen for each argument of a log
-	// message.
-	*(*reflect.SliceHeader)(unsafe.Pointer(&b)) = *(*reflect.SliceHeader)(unsafe.Pointer(&a))
+func noescape(v interface{}) (u interface{}) {
+	type eface [2]uintptr
+	*(*eface)(unsafe.Pointer(&u)) = *(*eface)(unsafe.Pointer(&v))
 	return
 }

--- a/httpevents/request_unsafe.go
+++ b/httpevents/request_unsafe.go
@@ -14,18 +14,18 @@ func bytesToStringNonEmpty(b []byte) string {
 	}))
 }
 
-func convS2E(s *string) (v interface{}) {
-	e := (*eface)(unsafe.Pointer(&v))
-	e.t = stringType
-	e.v = unsafe.Pointer(s)
-	return
+func convS2E(s *string) interface{} {
+	return *(*interface{})(unsafe.Pointer(&eface{
+		t: stringType,
+		v: unsafe.Pointer(s),
+	}))
 }
 
-func convI2E(i *int) (v interface{}) {
-	e := (*eface)(unsafe.Pointer(&v))
-	e.t = intType
-	e.v = unsafe.Pointer(i)
-	return
+func convI2E(i *int) interface{} {
+	return *(*interface{})(unsafe.Pointer(&eface{
+		t: intType,
+		v: unsafe.Pointer(i),
+	}))
 }
 
 type eface struct {

--- a/logger.go
+++ b/logger.go
@@ -203,10 +203,11 @@ func (s *logState) Write(b []byte) (n int, err error) {
 var logPool = sync.Pool{
 	New: func() interface{} {
 		return &logState{
-			e:   Event{Args: make(Args, 0, 8)},
-			fmt: make([]byte, 0, 512),
-			msg: make([]byte, 0, 512),
-			src: make([]byte, 0, 512),
+			e:    Event{Args: make(Args, 0, 8)},
+			fmt:  make([]byte, 0, 512),
+			msg:  make([]byte, 0, 512),
+			src:  make([]byte, 0, 512),
+			args: make([]interface{}, 0, 8),
 		}
 	},
 }

--- a/logger.go
+++ b/logger.go
@@ -128,6 +128,7 @@ func (l *Logger) log(depth int, debug bool, format string, args ...interface{}) 
 
 	h.HandleEvent(&s.e)
 
+	// don't hold pointers to let the garbage collector free the objects
 	for i := range s.e.Args {
 		s.e.Args[i] = Arg{}
 	}

--- a/logger.go
+++ b/logger.go
@@ -110,7 +110,7 @@ func (l *Logger) log(depth int, debug bool, format string, args ...interface{}) 
 	}
 
 	if n := len(args); n != 0 {
-		if s, ok := noescape(args[n-1]).(Args); ok {
+		if s, ok := args[n-1].(Args); ok {
 			a, args = s, args[:n-1]
 		}
 	}
@@ -119,11 +119,7 @@ func (l *Logger) log(depth int, debug bool, format string, args ...interface{}) 
 	s.fmt, s.e.Args = appendFormat(s.fmt, s.e.Args, format, args)
 	s.e.Args = append(s.e.Args, a...)
 
-	for _, v := range args {
-		s.args = append(s.args, noescape(v))
-	}
-
-	fmt.Fprintf(s, bytesToString(s.fmt), s.args...)
+	fmt.Fprintf(s, bytesToString(s.fmt), args...)
 
 	s.e.Message = bytesToString(s.msg)
 	s.e.Source = bytesToString(s.src)
@@ -136,10 +132,6 @@ func (l *Logger) log(depth int, debug bool, format string, args ...interface{}) 
 		s.e.Args[i] = Arg{}
 	}
 
-	for i := range s.args {
-		s.args[i] = nil
-	}
-
 	s.e.Message = ""
 	s.e.Source = ""
 	s.e.Args = s.e.Args[:0]
@@ -147,11 +139,9 @@ func (l *Logger) log(depth int, debug bool, format string, args ...interface{}) 
 	s.fmt = s.fmt[:0]
 	s.msg = s.msg[:0]
 	s.src = s.src[:0]
-	s.args = s.args[:0]
 
 	logPool.Put(s)
 	return
-
 }
 
 // Debug is like Log but only produces events if the logger has debugging
@@ -203,11 +193,10 @@ func (s *logState) Write(b []byte) (n int, err error) {
 var logPool = sync.Pool{
 	New: func() interface{} {
 		return &logState{
-			e:    Event{Args: make(Args, 0, 8)},
-			fmt:  make([]byte, 0, 512),
-			msg:  make([]byte, 0, 512),
-			src:  make([]byte, 0, 512),
-			args: make([]interface{}, 0, 8),
+			e:   Event{Args: make(Args, 0, 8)},
+			fmt: make([]byte, 0, 512),
+			msg: make([]byte, 0, 512),
+			src: make([]byte, 0, 512),
 		}
 	},
 }
@@ -262,7 +251,7 @@ func appendFormat(dstFmt []byte, dstArgs Args, srcFmt string, srcArgs []interfac
 
 		if len(key) != 0 {
 			if j < len(srcArgs) {
-				val = noescape(srcArgs[j])
+				val = srcArgs[j]
 			} else {
 				val = missing
 			}

--- a/logger.go
+++ b/logger.go
@@ -177,11 +177,10 @@ func (l *Logger) With(args Args) *Logger {
 
 // logState is used to build events produced by Logger instances.
 type logState struct {
-	e    Event
-	fmt  []byte
-	msg  []byte
-	src  []byte
-	args []interface{}
+	e   Event
+	fmt []byte
+	msg []byte
+	src []byte
 }
 
 func (s *logState) Write(b []byte) (n int, err error) {


### PR DESCRIPTION
Follow up of https://github.com/segmentio/events/pull/22 

Fixes the crash (mostly just disabling the unsafe optimization). I don't fully grasp why the GC complained here, I think it has to do with the fact that some heap allocated objects ended up with pointers to stack allocated values.
