### PR TITLE
fix line number

### DIFF
--- a/ecslogs/handler_test.go
+++ b/ecslogs/handler_test.go
@@ -43,7 +43,7 @@ func TestHandler(t *testing.T) {
 		b.Reset()
 		h.HandleEvent(e)
 
-		if s := b.String(); s != `{"level":"ERROR","time":"2017-01-01T23:42:00.123Z","info":{"source":"github.com/segmentio/events/ecslogs/handler_test.go:19","errors":[{"type":"*errors.errorString","error":"EOF","stack":["github.com/segmentio/events/ecslogs/handler_test.go:41","testing/testing.go:611","runtime/asm_amd64.s:2087"]}]},"data":{"name":"Luke","from":"Han"},"message":"Hello Luke!"}
+		if s := b.String(); s != `{"level":"ERROR","time":"2017-01-01T23:42:00.123Z","info":{"source":"github.com/segmentio/events/ecslogs/handler_test.go:19","errors":[{"type":"*errors.errorString","error":"EOF","stack":["github.com/segmentio/events/ecslogs/handler_test.go:41","testing/testing.go:657","runtime/asm_amd64.s:2197"]}]},"data":{"name":"Luke","from":"Han"},"message":"Hello Luke!"}
 ` {
 			// This test is sensitive, it may break if the Go version changes or
 			// if this file is edited (because the number of lines may not be

--- a/source.go
+++ b/source.go
@@ -1,17 +1,14 @@
 package events
 
-import (
-	"runtime"
-	"strings"
-)
+import "strings"
 
 // SourceForPC returns the file and line given a program counter address.
 // The file path is in the canonical form for Go programs, starting with
 // the package path.
 func SourceForPC(pc uintptr) (file string, line int) {
-	fn := runtime.FuncForPC(pc)
-	file, line = fn.FileLine(pc)
-	file = trimGOPATH(fn.Name(), file)
+	var name string
+	file, line, name = fileLineFunc(pc)
+	file = trimGOPATH(name, file)
 	return
 }
 

--- a/source_default.go
+++ b/source_default.go
@@ -1,0 +1,12 @@
+// +build !go1.7
+
+package events
+
+import "runtime"
+
+func fileLineFunc(pc uintptr) (file string, line int, name string) {
+	fn := runtime.FuncForPC(pc)
+	file, line = fn.FileLine(pc)
+	name = fn.Name()
+	return
+}

--- a/source_go17.go
+++ b/source_go17.go
@@ -1,0 +1,15 @@
+// +build go1.7
+
+package events
+
+import "runtime"
+
+func fileLineFunc(pc uintptr) (file string, line int, name string) {
+	caller := [1]uintptr{pc}
+	frames := runtime.CallersFrames(caller[:])
+	f, _ := frames.Next()
+	file = f.File
+	line = f.Line
+	name = f.Func.Name()
+	return
+}

--- a/source_test.go
+++ b/source_test.go
@@ -15,7 +15,7 @@ func TestSourceForPC(t *testing.T) {
 		t.Error("bad file:", file)
 	}
 
-	if line != 12 {
+	if line != 10 {
 		t.Error("bad line:", line)
 	}
 }


### PR DESCRIPTION
Related resources:
- https://github.com/golang/go/issues/19426
- https://golang.org/pkg/runtime/#Func.FileLine
- https://golang.org/pkg/runtime/#Callers
> Note that since each slice entry pc[i] is a return program counter, looking up the file and line for pc[i] (for example, using (*Func).FileLine) will normally return the file and line number of the instruction immediately following the call. To easily look up file/line information for the call sequence, use Frames.

Go 1.7 introduced a new API to get accurate file/line numbers on the call stack, apparently some changes were made that causes `runtime.FileForFunc` to not be as straight-forward to use as it used to (I didn't really dig into the details).

For this program:
```go
package main

import (
	"github.com/segmentio/events"
	_ "github.com/segmentio/events/text"
)

func main() {
	events.DefaultLogger.EnableDebug = true
	events.DefaultLogger.EnableSource = true
	events.Log("hello")
	events.Debug("world")
}
```
On master we get the following output:
```
$ go run ./main.go
main[12798]: 2017-08-22 05:50:14.023 - tmp/main.go:12 - hello
main[12798]: 2017-08-22 05:50:14.024 - tmp/main.go:13 - world
```
On this branch, the output is:
```
$ go run ./main.go
main[12718]: 2017-08-22 05:49:56.477 - tmp/main.go:11 - hello
main[12718]: 2017-08-22 05:49:56.477 - tmp/main.go:12 - world
```
There's an off-by-one error on master, which is fixed by this PR.