### PR TITLE
Add eventstest package.

### DIFF
--- a/eventstest/handler.go
+++ b/eventstest/handler.go
@@ -1,0 +1,61 @@
+package eventstest
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/segmentio/events"
+)
+
+var _ events.Handler = (*Handler)(nil)
+
+// Handler is a stats handler that can record events for inspection and make
+// assertions on them.
+type Handler struct {
+	evList []events.Event
+	sync.Mutex
+}
+
+// HandleEvent implements the events.Handler interface.
+func (h *Handler) HandleEvent(e *events.Event) {
+	h.Lock()
+	defer h.Unlock()
+	h.evList = append(h.evList, *e.Clone())
+}
+
+// AssertEvents asserts that the given events were handled by the handler.
+// It only checks the following event fields for equality — .Args, .Debug and .Message.
+// It ignores the .Source and .Time fields.
+func (h *Handler) AssertEvents(t testing.TB, expectedEvents ...events.Event) {
+	h.Lock()
+	defer h.Unlock()
+
+	if len(h.evList) != len(expectedEvents) {
+		t.Errorf("expected %d events but got %d events: %v", len(expectedEvents), len(h.evList), h.evList)
+		return
+	}
+
+	for i := 0; i < len(h.evList); i++ {
+		got := h.evList[i]
+		expected := expectedEvents[i]
+		if !assertEqualEvent(t, got, expected) {
+			t.Errorf("expected event %+v at index %s but got %+v", expected, i, got)
+			return
+		}
+	}
+}
+
+func assertEqualEvent(t testing.TB, got, expected events.Event) bool {
+	return assertEqualField(t, "Args", got.Args, expected.Args) &&
+		assertEqualField(t, "Debug", got.Debug, expected.Debug) &&
+		assertEqualField(t, "Message", got.Message, expected.Message)
+}
+
+func assertEqualField(t testing.TB, field string, got, expected interface{}) bool {
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("expected .%s to be %v but got %v", field, expected, got)
+		return false
+	}
+	return true
+}

--- a/eventstest/handler_test.go
+++ b/eventstest/handler_test.go
@@ -1,0 +1,24 @@
+package eventstest
+
+import (
+	"testing"
+
+	"github.com/segmentio/events"
+)
+
+func TestHandler(t *testing.T) {
+	h := &Handler{}
+	logger := events.NewLogger(h)
+
+	logger.Log("Hello %{name}s!", "Luke", events.Args{
+		{"from", "Han"},
+	})
+
+	h.AssertEvents(t, events.Event{
+		Message: "Hello Luke!",
+		Args: events.Args{
+			{"name", "Luke"},
+			{"from", "Han"},
+		},
+	})
+}


### PR DESCRIPTION
This includes a Handler implementation that can do the following:

1. Keep an internal copy of events it handles.
2. Make assertions on these events.

It makes assertions directly rather than leaving it upto clients to
simplify usage. From our usage this includes:

1. Ignoring unpredictable fields like source and time.
2. Printing error messages that pinpoint what went wrong.

Here's an example of the error message:

```
--- FAIL: TestHandler (0.00s)
        handler.go:60: expected .Args to be [{from Han}] but got [{name
          Luke} {from Han}]
        handler.go:43: expected event {Message:Hello Luke! Source:
          Args:[{Name:from Value:Han}] Time:0001-01-01 00:00:00 +0000 UTC
          Debug:false} at index %!s(int=0) but got {Message:Hello Luke!
          Source:github.com/segmentio/events/eventstest/handler_test.go:20
          Args:[{Name:name Value:Luke} {Name:from Value:Han}]
          Time:2017-08-22 12:40:37.735500081 -0700 PDT Debug:false}
    FAIL
```

I want to use this for `rpcevents`. I'll admit I got a bit carried away here. Originally I started by just exposing an `Events` function on the handler and letting clients assert on it, but I saw a lot of common code that we could eliminate (e.g. assert on length of events and dealing with predictable fields).