### PR TITLE
Capture http headers

### DIFF
--- a/event.go
+++ b/event.go
@@ -37,7 +37,7 @@ func (e *Event) Clone() *Event {
 		a = make(Args, n)
 		for i := range a {
 			a[i].Name = e.Args[i].Name
-			a[i].Value = cloneValue(e.Args[i].Value)
+			a[i].Value = clone(e.Args[i].Value)
 		}
 	}
 
@@ -58,6 +58,17 @@ func (e *Event) Clone() *Event {
 		Time:    e.Time,
 		Debug:   e.Debug,
 	}
+}
+
+type cloner interface {
+	Clone() interface{}
+}
+
+func clone(v interface{}) interface{} {
+	if c, ok := v.(cloner); ok {
+		return c.Clone()
+	}
+	return cloneValue(v)
 }
 
 // Args reprsents a list of event arguments.

--- a/eventstest/handler.go
+++ b/eventstest/handler.go
@@ -40,7 +40,9 @@ func (h *Handler) AssertEvents(t testing.TB, expectedEvents ...events.Event) {
 		got := h.evList[i]
 		expected := expectedEvents[i]
 		if !assertEqualEvent(t, got, expected) {
-			t.Errorf("expected event %+v at index %d but got %+v", expected, i, got)
+			t.Error("bad events at index", i)
+			t.Log("expected =>", expected)
+			t.Log("got ======>", got)
 			return
 		}
 	}
@@ -54,7 +56,9 @@ func assertEqualEvent(t testing.TB, got, expected events.Event) bool {
 
 func assertEqualField(t testing.TB, field string, got, expected interface{}) bool {
 	if !reflect.DeepEqual(got, expected) {
-		t.Errorf("expected .%s to be %v but got %v", field, expected, got)
+		t.Errorf("bad .%s:", field)
+		t.Log("expected =>", expected)
+		t.Log("got ======>", got)
 		return false
 	}
 	return true

--- a/eventstest/handler.go
+++ b/eventstest/handler.go
@@ -40,7 +40,7 @@ func (h *Handler) AssertEvents(t testing.TB, expectedEvents ...events.Event) {
 		got := h.evList[i]
 		expected := expectedEvents[i]
 		if !assertEqualEvent(t, got, expected) {
-			t.Errorf("expected event %+v at index %s but got %+v", expected, i, got)
+			t.Errorf("expected event %+v at index %d but got %+v", expected, i, got)
 			return
 		}
 	}

--- a/httpevents/handler.go
+++ b/httpevents/handler.go
@@ -103,7 +103,7 @@ func (w *responseWriter) log(depth int, status int) {
 		w.logger = nil
 		w.request.status = status
 		w.request.statusText = http.StatusText(status)
-		w.request.log(logger, depth+1)
+		w.request.log(logger, w.ResponseWriter.Header(), depth+1)
 	}
 }
 

--- a/httpevents/handler_test.go
+++ b/httpevents/handler_test.go
@@ -68,7 +68,8 @@ func TestHandler(t *testing.T) {
 			{"query", "answer=42"},
 			{"fragment", "universe"},
 			{"status", 202},
-			{"headers", &headerList{{"User-Agent", "httpevents"}}},
+			{"request-headers", &headerList{{"User-Agent", "httpevents"}}},
+			{"response-headers", &headerList{}},
 		},
 		Debug: true,
 	})
@@ -107,7 +108,8 @@ func TestHandlerPanic(t *testing.T) {
 			{"method", "POST"},
 			{"path", "/"},
 			{"status", 500},
-			{"headers", &headerList{{"User-Agent", "httpevents"}}},
+			{"request-headers", &headerList{{"User-Agent", "httpevents"}}},
+			{"response-headers", &headerList{}},
 		},
 	})
 }

--- a/httpevents/handler_test.go
+++ b/httpevents/handler_test.go
@@ -68,8 +68,8 @@ func TestHandler(t *testing.T) {
 			{"query", "answer=42"},
 			{"fragment", "universe"},
 			{"status", 202},
-			{"request-headers", &headerList{{"User-Agent", "httpevents"}}},
-			{"response-headers", &headerList{}},
+			{"request", &headerList{{"User-Agent", "httpevents"}}},
+			{"response", &headerList{}},
 		},
 		Debug: true,
 	})
@@ -108,8 +108,8 @@ func TestHandlerPanic(t *testing.T) {
 			{"method", "POST"},
 			{"path", "/"},
 			{"status", 500},
-			{"request-headers", &headerList{{"User-Agent", "httpevents"}}},
-			{"response-headers", &headerList{}},
+			{"request", &headerList{{"User-Agent", "httpevents"}}},
+			{"response", &headerList{}},
 		},
 	})
 }

--- a/httpevents/handler_test.go
+++ b/httpevents/handler_test.go
@@ -68,7 +68,7 @@ func TestHandler(t *testing.T) {
 			{"query", "answer=42"},
 			{"fragment", "universe"},
 			{"status", 202},
-			{"agent", "httpevents"},
+			{"headers", &headerList{{"User-Agent", "httpevents"}}},
 		},
 		Debug: true,
 	})
@@ -107,7 +107,7 @@ func TestHandlerPanic(t *testing.T) {
 			{"method", "POST"},
 			{"path", "/"},
 			{"status", 500},
-			{"agent", "httpevents"},
+			{"headers", &headerList{{"User-Agent", "httpevents"}}},
 		},
 	})
 }

--- a/httpevents/header.go
+++ b/httpevents/header.go
@@ -1,0 +1,39 @@
+package httpevents
+
+import (
+	"fmt"
+
+	"github.com/segmentio/objconv"
+)
+
+// An ordered list of HTTP headers.
+type headerList []header
+
+type header struct {
+	name  string
+	value string
+}
+
+func (h *headerList) String() string {
+	return fmt.Sprint(*h)
+}
+
+func (h *headerList) Clone() interface{} {
+	c := make(headerList, len(*h))
+	copy(c, *h)
+	return &c
+}
+
+func (h *headerList) EncodeValue(e objconv.Encoder) error {
+	i := 0
+	return e.EncodeMap(len(*h), func(k objconv.Encoder, v objconv.Encoder) error {
+		if err := k.Encode(&(*h)[i].name); err != nil {
+			return err
+		}
+		if err := v.Encode(&(*h)[i].value); err != nil {
+			return err
+		}
+		i++
+		return nil
+	})
+}

--- a/httpevents/header.go
+++ b/httpevents/header.go
@@ -2,6 +2,8 @@ package httpevents
 
 import (
 	"fmt"
+	"net/http"
+	"sort"
 
 	"github.com/segmentio/objconv"
 )
@@ -12,6 +14,28 @@ type headerList []header
 type header struct {
 	name  string
 	value string
+}
+
+func (h headerList) clear() {
+	for i := range h {
+		h[i] = header{}
+	}
+}
+
+func (h *headerList) set(httpHeader http.Header) {
+	list := (*h)[:0]
+
+	for name, values := range httpHeader {
+		for _, value := range values {
+			list = append(list, header{
+				name:  name,
+				value: value,
+			})
+		}
+	}
+
+	*h = list
+	sort.Sort(h)
 }
 
 func (h *headerList) String() string {
@@ -37,3 +61,7 @@ func (h *headerList) EncodeValue(e objconv.Encoder) error {
 		return nil
 	})
 }
+
+func (h *headerList) Len() int               { return len(*h) }
+func (h *headerList) Less(i int, j int) bool { return (*h)[i].name < (*h)[j].name }
+func (h *headerList) Swap(i int, j int)      { (*h)[i], (*h)[j] = (*h)[j], (*h)[i] }

--- a/httpevents/request.go
+++ b/httpevents/request.go
@@ -90,11 +90,11 @@ func (r *request) log(logger *events.Logger, resHeader http.Header, depth int) {
 	r.resHeaders.set(resHeader)
 	r.extraArgs = append(r.extraArgs[:0],
 		events.Arg{
-			Name:  "request-headers",
+			Name:  "request",
 			Value: &r.reqHeaders,
 		},
 		events.Arg{
-			Name:  "response-headers",
+			Name:  "response",
 			Value: &r.resHeaders,
 		},
 	)

--- a/httpevents/request.go
+++ b/httpevents/request.go
@@ -23,6 +23,7 @@ type request struct {
 	fragment   string
 	agent      string
 	headers    headerList
+	extraArgs  events.Args
 	status     int
 	statusText string
 	fmtbuf     []byte
@@ -101,6 +102,11 @@ func (r *request) reset(req *http.Request, laddr string) {
 	}
 
 	sort.Sort(r)
+
+	r.extraArgs = append(r.extraArgs[:0], events.Arg{
+		Name:  "headers",
+		Value: &r.headers,
+	})
 }
 
 // Implement sort.Interface to sort the list of headers without requiring an
@@ -135,10 +141,7 @@ func (r *request) log(logger *events.Logger, depth int) {
 	}
 	fmt = append(fmt, " - %{status}d %s - %q"...)
 	arg = append(arg, convI2E(&r.status), convS2E(&r.statusText), convS2E(&r.agent))
-	arg = append(arg, events.Args{{
-		Name:  "headers",
-		Value: &r.headers,
-	}})
+	arg = append(arg, convA2E(&r.extraArgs))
 
 	// Adjust the call depth so we can track the caller of the handler or the
 	// transport outside of the httpevents package.

--- a/httpevents/request_safe.go
+++ b/httpevents/request_safe.go
@@ -2,6 +2,8 @@
 
 package httpevents
 
+import "github.com/segmentio/events"
+
 func bytesToStringNonEmpty(b []byte) string {
 	return string(b)
 }
@@ -12,4 +14,8 @@ func convS2E(s *string) interface{} {
 
 func convI2E(i *int) interface{} {
 	return *i
+}
+
+func convA2E(a *events.Args) interface{} {
+	return *a
 }

--- a/httpevents/request_test.go
+++ b/httpevents/request_test.go
@@ -22,7 +22,7 @@ func BenchmarkRequestLog(b *testing.B) {
 	l := &events.Logger{}
 
 	for i := 0; i != b.N; i++ {
-		r.log(l, 0)
+		r.log(l, nil, 0)
 	}
 }
 

--- a/httpevents/request_unsafe.go
+++ b/httpevents/request_unsafe.go
@@ -5,6 +5,8 @@ package httpevents
 import (
 	"reflect"
 	"unsafe"
+
+	"github.com/segmentio/events"
 )
 
 func bytesToStringNonEmpty(b []byte) string {
@@ -15,16 +17,21 @@ func bytesToStringNonEmpty(b []byte) string {
 }
 
 func convS2E(s *string) interface{} {
-	return *(*interface{})(unsafe.Pointer(&eface{
-		t: stringType,
-		v: unsafe.Pointer(s),
-	}))
+	return convT2E(stringType, unsafe.Pointer(s))
 }
 
 func convI2E(i *int) interface{} {
+	return convT2E(intType, unsafe.Pointer(i))
+}
+
+func convA2E(a *events.Args) interface{} {
+	return convT2E(argsType, unsafe.Pointer(a))
+}
+
+func convT2E(t unsafe.Pointer, v unsafe.Pointer) interface{} {
 	return *(*interface{})(unsafe.Pointer(&eface{
-		t: intType,
-		v: unsafe.Pointer(i),
+		t: t,
+		v: v,
 	}))
 }
 
@@ -40,4 +47,5 @@ func typeOf(v interface{}) unsafe.Pointer {
 var (
 	intType    = typeOf(0)
 	stringType = typeOf("")
+	argsType   = typeOf((events.Args)(nil))
 )

--- a/httpevents/transport.go
+++ b/httpevents/transport.go
@@ -28,7 +28,7 @@ func (t *transport) RoundTrip(req *http.Request) (res *http.Response, err error)
 		r := acquireRequest(req, "*")
 		r.status = res.StatusCode
 		r.statusText = http.StatusText(res.StatusCode)
-		r.log(t.logger, 1)
+		r.log(t.logger, res.Header, 1)
 		releaseRequest(r)
 	}
 	return

--- a/httpevents/transport_test.go
+++ b/httpevents/transport_test.go
@@ -53,10 +53,10 @@ func TestTransport(t *testing.T) {
 			{"method", "GET"},
 			{"path", "/"},
 			{"status", 200},
-			{"request-headers", &headerList{
+			{"request", &headerList{
 				{"User-Agent", "httpevents"},
 			}},
-			{"response-headers", &headerList{
+			{"response", &headerList{
 				{"Content-Length", "12"},
 				{"Content-Type", "text/plain; charset=utf-8"},
 				{"Date", "today"},

--- a/httpevents/transport_test.go
+++ b/httpevents/transport_test.go
@@ -31,6 +31,7 @@ func TestTransport(t *testing.T) {
 		t.Error(err)
 		return
 	}
+	defer res.Body.Close()
 
 	b, err := ioutil.ReadAll(res.Body)
 	if err != nil {

--- a/httpevents/transport_test.go
+++ b/httpevents/transport_test.go
@@ -51,7 +51,7 @@ func TestTransport(t *testing.T) {
 			{"method", "GET"},
 			{"path", "/"},
 			{"status", 200},
-			{"agent", "httpevents"},
+			{"headers", &headerList{{"User-Agent", "httpevents"}}},
 		},
 		Debug: true,
 	})

--- a/httpevents/transport_test.go
+++ b/httpevents/transport_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestTransport(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Header().Set("Date", "today")
 		res.WriteHeader(http.StatusOK)
 		res.Write([]byte("Hello World!"))
 	}))
@@ -52,7 +53,14 @@ func TestTransport(t *testing.T) {
 			{"method", "GET"},
 			{"path", "/"},
 			{"status", 200},
-			{"headers", &headerList{{"User-Agent", "httpevents"}}},
+			{"request-headers", &headerList{
+				{"User-Agent", "httpevents"},
+			}},
+			{"response-headers", &headerList{
+				{"Content-Length", "12"},
+				{"Content-Type", "text/plain; charset=utf-8"},
+				{"Date", "today"},
+			}},
 		},
 		Debug: true,
 	})


### PR DESCRIPTION
This PR changes the http decorators to inject the request and response headers in the event arguments.

I'm having issues with the S3 API returning 501 due to unsupported headers on some requests, but because we're not recording the headers I have no way to know what was misconfigured, which is what motivated this change.

Please take a look and let me know if anything should be changed.