### PR TITLE
test signal errors

### DIFF
--- a/signal.go
+++ b/signal.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 )
 
@@ -134,4 +135,33 @@ func (s *signalCtx) cancel(err error) {
 		s.err.Store(err)
 		close(s.done)
 	})
+}
+
+// IsSignalError returns true if the given error is a *SignalError that was
+// generated upon receipt of one of the given signals. If no signal is passed,
+// the function only tests for err to be of type *SgianlError.
+func IsSignal(err error, signals ...os.Signal) bool {
+	if e, ok := err.(*SignalError); ok {
+		if len(signals) == 0 {
+			return true
+		}
+		for _, signal := range signals {
+			if signal == e.Signal {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// IsTermination returns true if the given error was caused by receiving a
+// termination signal.
+func IsTermination(err error) bool {
+	return IsSignal(err, syscall.SIGTERM)
+}
+
+// IsInterruption returns true if the given error was caused by receiving an
+// interruption signal.
+func IsInterruption(err error) bool {
+	return IsSignal(err, syscall.SIGINT)
 }

--- a/signal.go
+++ b/signal.go
@@ -137,9 +137,9 @@ func (s *signalCtx) cancel(err error) {
 	})
 }
 
-// IsSignalError returns true if the given error is a *SignalError that was
-// generated upon receipt of one of the given signals. If no signal is passed,
-// the function only tests for err to be of type *SgianlError.
+// IsSignal returns true if the given error is a *SignalError that was
+// generated upon receipt of one of the given signals. If no signal is
+// passed, the function only tests for err to be of type *SginalError.
 func IsSignal(err error, signals ...os.Signal) bool {
 	if e, ok := err.(*SignalError); ok {
 		if len(signals) == 0 {

--- a/signal_test.go
+++ b/signal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"reflect"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -116,4 +117,22 @@ func TestWithSignals(t *testing.T) {
 			t.Error("the parent error wasn't reported:", err)
 		}
 	})
+}
+
+func TestIsTermination(t *testing.T) {
+	if !IsTermination(&SignalError{Signal: syscall.SIGTERM}) {
+		t.Error("SIGTERM wasn't recognized as a termination error")
+	}
+	if IsTermination(&SignalError{Signal: syscall.SIGINT}) {
+		t.Error("SIGINT was mistakenly recognized as a termination error")
+	}
+}
+
+func TestIsInterruption(t *testing.T) {
+	if !IsInterruption(&SignalError{Signal: syscall.SIGINT}) {
+		t.Error("SIGINT wasn't recognized as a interruption error")
+	}
+	if IsInterruption(&SignalError{Signal: syscall.SIGTERM}) {
+		t.Error("SIGTERM was mistakenly recognized as a interruption error")
+	}
 }


### PR DESCRIPTION
This PR adds helper functions to test for errors caused by receiving signals. The intent is to make it simple for an application to identify those and prevent pointless logging of an error when it's actually expected behavior.