### PR TITLE
Delete Authorization header from logs

### DIFF
--- a/httpevents/handler_test.go
+++ b/httpevents/handler_test.go
@@ -54,6 +54,9 @@ func TestHandler(t *testing.T) {
 	log := events.NewLogger(eventsHandler)
 
 	h := NewHandlerWith(log, http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		if req.Header.Get("Authorization") != "this will be deleted" {
+			t.Error("Authorization header should not change in request handler")
+		}
 		res.WriteHeader(http.StatusAccepted)
 	}))
 	h.ServeHTTP(res, req)

--- a/httpevents/handler_test.go
+++ b/httpevents/handler_test.go
@@ -41,6 +41,7 @@ func TestHandler(t *testing.T) {
 
 	req := httptest.NewRequest("GET", "/hello?answer=42", nil)
 	req.Header.Set("User-Agent", "httpevents")
+	req.Header.Set("Authorization", "this will be deleted")
 	req.URL.Fragment = "universe" // for some reason NewRequest doesn't parses this
 	req.Host = "www.github.com"
 	req.RemoteAddr = "127.0.0.1:56789"

--- a/httpevents/header.go
+++ b/httpevents/header.go
@@ -26,6 +26,11 @@ func (h *headerList) set(httpHeader http.Header) {
 	list := (*h)[:0]
 
 	for name, values := range httpHeader {
+		// Do not accept and log headers that contain credentials
+		if name == "Authorization" {
+			continue
+		}
+
 		for _, value := range values {
 			list = append(list, header{
 				name:  name,

--- a/httpevents/request.go
+++ b/httpevents/request.go
@@ -75,9 +75,6 @@ func (r *request) reset(req *http.Request, laddr string) {
 		raddr = "???"
 	}
 
-	// We delete the authorization header such that private secrets are not logged
-	req.Header.Del("Authorization")
-
 	r.laddr = laddr
 	r.raddr = raddr
 	r.method = req.Method

--- a/httpevents/request.go
+++ b/httpevents/request.go
@@ -75,6 +75,9 @@ func (r *request) reset(req *http.Request, laddr string) {
 		raddr = "???"
 	}
 
+	// We delete the authorization header such that private secrets are not logged
+	req.Header.Del("Authorization")
+
 	r.laddr = laddr
 	r.raddr = raddr
 	r.method = req.Method


### PR DESCRIPTION
Currently, the httpevents logger logs all headers. This opens the possibility for logging credentials via the Authorization header. This PR removes the Authorization header to prevent situations of logging credentials to logs