### PR TITLE
init: add build flags for testing protection

### DIFF
--- a/ecslogs/init.go
+++ b/ecslogs/init.go
@@ -1,3 +1,5 @@
+// +build !testing
+
 package ecslogs
 
 import (
@@ -8,6 +10,7 @@ import (
 )
 
 func init() {
+
 	if !events.IsTerminal(1) {
 		events.DefaultHandler = &Handler{
 			Output:  os.Stdout,

--- a/log/init.go
+++ b/log/init.go
@@ -1,3 +1,5 @@
+// +build !testing
+
 package log
 
 import "log"

--- a/sigevents/init.go
+++ b/sigevents/init.go
@@ -1,3 +1,5 @@
+// +build !testing
+
 package sigevents
 
 import (

--- a/text/handler.go
+++ b/text/handler.go
@@ -12,6 +12,12 @@ import (
 // DefaultTimeFormat is the default time format set on Handler.
 const DefaultTimeFormat = "2006-01-02 15:04:05.000"
 
+// DefaultPrefix is used by the default handler configured when the program's
+// standard output is a terminal.
+//
+// The value is "program-name[pid]: "
+var DefaultPrefix string
+
 // Handler is an event handler which format events in a human-readable format
 // and writes them to its output.
 //

--- a/text/init.go
+++ b/text/init.go
@@ -1,3 +1,5 @@
+// +build !testing
+
 package text
 
 import (
@@ -8,13 +10,8 @@ import (
 	"github.com/segmentio/events"
 )
 
-// DefaultPrefix is used by the default handler configured when the program's
-// standard output is a terminal.
-//
-// The value is "program-name[pid]: "
-var DefaultPrefix string
-
 func init() {
+
 	DefaultPrefix = fmt.Sprintf("%s[%d]: ", filepath.Base(os.Args[0]), os.Getpid())
 
 	if events.IsTerminal(1) {


### PR DESCRIPTION
When testing using `./...` syntax for your packages, events init
functions set in main packages may override init functions set in
testing packages.  This is undesirable for debugging testing packages.

This CR makes it so that import side effects do not happen.  All updates
must be explicit when tests are ran with the `test` tag.

e.g. `go test -tags testing ./...` will not call any init side effects
defined in `segmentio/events`.

https://stackoverflow.com/questions/14249217/how-do-i-know-im-running-within-go-test