### PR TITLE
Document which response codes are logged by `httpstats`

### DIFF
--- a/httpevents/handler.go
+++ b/httpevents/handler.go
@@ -9,9 +9,9 @@ import (
 	"github.com/segmentio/events"
 )
 
-// NewHandler wraps the HTTP handler and returns a new handler which logs all
-// requests with the default logger.
-// 4xx and 5xx responses will be logged, while all other responses are debug logged.
+// NewHandler wraps the HTTP handler and returns a new handler which logs all 4xx
+// and 5xx requests with the default logger. All other requests will only be logged
+// in debug mode.
 func NewHandler(handler http.Handler) http.Handler {
 	return NewHandlerWith(events.DefaultLogger, handler)
 }

--- a/httpevents/handler.go
+++ b/httpevents/handler.go
@@ -11,6 +11,7 @@ import (
 
 // NewHandler wraps the HTTP handler and returns a new handler which logs all
 // requests with the default logger.
+// 4xx and 5xx responses will be logged, while all other responses are debug logged.
 func NewHandler(handler http.Handler) http.Handler {
 	return NewHandlerWith(events.DefaultLogger, handler)
 }


### PR DESCRIPTION
Took me a bit to realize that some response codes are logged, while other are only logged in debug mode:

```go
// httpevents/request.go
switch {
case is4xx(r.status) || is5xx(r.status):
	l.Log(bytesToStringNonEmpty(fmt), arg...)
default:
	l.Debug(bytesToStringNonEmpty(fmt), arg...)
}
```

This PR just adds a small doc comment to clarify this.