### PR TITLE
netevents: don't bind to 0.0.0.0

### DIFF
--- a/netevents/listener_test.go
+++ b/netevents/listener_test.go
@@ -16,7 +16,7 @@ func TestListener(t *testing.T) {
 		evList = append(evList, e.Clone())
 	}))
 
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
On Mac, this flashes up a dialog about how the binary is listening on all interfaces.