### PR TITLE
logger: deprecate the events logging functionality

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -14,11 +14,17 @@ import (
 var DefaultLogger = NewLogger(nil)
 
 // Log emits a log event to the default logger.
+//
+// Deprecated: Use the log/slog standard library package (or Segment internal,
+// github.com/segmentio/log).
 func Log(format string, args ...interface{}) {
 	DefaultLogger.log(1, false, format, args...)
 }
 
 // Debug emits a debug event to the default logger.
+//
+// Deprecated: Use the log/slog standard library package (or Segment internal,
+// github.com/segmentio/log).
 func Debug(format string, args ...interface{}) {
 	DefaultLogger.debug(1, format, args...)
 }
@@ -75,6 +81,9 @@ type Logger struct {
 }
 
 // NewLogger allocates and returns a new logger which sends events to handler.
+//
+// Deprecated: Use the log/slog standard library package (or Segment internal,
+// github.com/segmentio/log).
 func NewLogger(handler Handler) *Logger {
 	return &Logger{
 		Handler:      handler,

--- a/signal.go
+++ b/signal.go
@@ -139,7 +139,7 @@ func (s *signalCtx) cancel(err error) {
 
 // IsSignal returns true if the given error is a *SignalError that was
 // generated upon receipt of one of the given signals. If no signal is
-// passed, the function only tests for err to be of type *SginalError.
+// passed, the function only tests for err to be of type *SignalError.
 func IsSignal(err error, signals ...os.Signal) bool {
 	if e, ok := err.(*SignalError); ok {
 		if len(signals) == 0 {


### PR DESCRIPTION
The new log/slog package in the standard library is good enough for the use cases we initially wrote this library to solve. Please use it!